### PR TITLE
Update on macOS version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ### ~~HI: 6.6.0 Global~~
 ### ~~HSR: 1.0.5 OS/CN (For Intel Mac Only)~~
 
-### **: For Apple Silicon users: Sonoma 14.4 is required (Currently in [Developer Beta](https://developer.apple.com/support/install-beta/))
+### **: For Apple Silicon users: Sonoma 14.4 and above is required
 
 ## Policy
 


### PR DESCRIPTION
This has been tested on Sonoma 14.4 with Apple M1 Max. Should also work for the other Apple Silicon chips.