### PR TITLE
Add HTTP Proxy setting

### DIFF
--- a/src/clients/mhy/bh3/program-launch-game.ts
+++ b/src/clients/mhy/bh3/program-launch-game.ts
@@ -79,6 +79,10 @@ cd /d "${wine.toWinePath(gameDir)}"
             : {
                 WINEESYNC: "1",
               }),
+          ...(config.proxyEnabled ? {
+            HTTP_PROXY: config.proxyHost,
+            HTTPS_PROXY: config.proxyHost,
+          } : {})
         },
         logfile
       ),

--- a/src/clients/mhy/hk4e/program-launch-game.ts
+++ b/src/clients/mhy/hk4e/program-launch-game.ts
@@ -137,6 +137,10 @@ ${await (async () => {
           : {
               WINEESYNC: "1",
             }),
+        ...(config.proxyEnabled ? {
+          HTTP_PROXY: config.proxyHost,
+          HTTPS_PROXY: config.proxyHost,
+        } : {})
       },
       logfile
     );

--- a/src/clients/mhy/hkrpg/program-launch-game.ts
+++ b/src/clients/mhy/hkrpg/program-launch-game.ts
@@ -78,6 +78,10 @@ cd /d "${wine.toWinePath(gameDir)}"
           : {
               WINEESYNC: "1",
             }),
+        ...(config.proxyEnabled ? {
+          HTTP_PROXY: config.proxyHost,
+          HTTPS_PROXY: config.proxyHost,
+        } : {})
       },
       logfile
     );

--- a/src/clients/mhy/nap/program-launch-game.ts
+++ b/src/clients/mhy/nap/program-launch-game.ts
@@ -76,6 +76,10 @@ cd /d "${wine.toWinePath(gameDir)}"
           : {
               WINEESYNC: "1",
             }),
+        ...(config.proxyEnabled ? {
+          HTTP_PROXY: config.proxyHost,
+          HTTPS_PROXY: config.proxyHost,
+        } : {})
       },
       logfile
     );

--- a/src/clients/seasun/cbjq/program-launch-game.ts
+++ b/src/clients/seasun/cbjq/program-launch-game.ts
@@ -83,6 +83,10 @@ cd /d "${wine.toWinePath(gameDir)}"
           : {
               WINEESYNC: "1",
             }),
+        ...(config.proxyEnabled ? {
+          HTTP_PROXY: config.proxyHost,
+          HTTPS_PROXY: config.proxyHost,
+        } : {})
       },
       logfile
     );

--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -36,6 +36,8 @@ import createFPSUnlock from "./fps-unlock";
 import { exec2, getKeyOrDefault, resolve, setKey } from "../utils";
 import { createSignal, JSXElement, Show } from "solid-js";
 import createReShade from "./reshade";
+import { createProxyEnabledConfig } from "@config/proxy-enabled";
+import { createProxyHostConfig } from "@config/proxy-host";
 
 export async function createConfiguration({
   wine,
@@ -70,6 +72,9 @@ export async function createConfiguration({
   const [UL] = await createLocaleConfig({ locale, config });
   const [FO] = await createFPSUnlock({ locale, config });
   const [RS] = await createReShade({ locale, config });
+
+  const [PRE] = await createProxyEnabledConfig({ locale, config });
+  const [PRH] = await createProxyHostConfig({ locale, config });
 
   const ChannelClientConfig = await configForChannelClient(locale, config);
 
@@ -139,6 +144,12 @@ export async function createConfiguration({
                       <MH />
                       <R />
                       <LC />
+                      <Divider />
+                      <PRE />
+                      <PRH />
+                      <Text userSelect={"none"} size="xs">
+                        {locale.get("SETTING_PROXY_DESC")}
+                      </Text>
                       <Divider />
                       <UL />
                       <FormControl>

--- a/src/config/proxy-enabled.tsx
+++ b/src/config/proxy-enabled.tsx
@@ -1,6 +1,5 @@
 import {
   Box, Checkbox,
-  createIcon,
   FormControl,
   FormLabel,
 } from "@hope-ui/solid";

--- a/src/config/proxy-enabled.tsx
+++ b/src/config/proxy-enabled.tsx
@@ -1,0 +1,68 @@
+import {
+  Box, Checkbox,
+  createIcon,
+  FormControl,
+  FormLabel,
+} from "@hope-ui/solid";
+import { createEffect, createSignal } from "solid-js";
+import { Locale } from "../locale";
+import { Config, NOOP } from "./config-def";
+import { assertValueDefined, getKey, setKey } from "@utils";
+
+declare module "./config-def" {
+  interface Config {
+    proxyEnabled: boolean;
+  }
+}
+
+export async function createProxyEnabledConfig({
+  config,
+  locale,
+}: {
+  config: Partial<Config>;
+  locale: Locale;
+}) {
+  try {
+    config.proxyEnabled = (await getKey("config_proxyEnabled")) == "true";
+  } catch {
+    config.proxyEnabled = false; // default value
+  }
+
+  const [value, setValue] = createSignal(config.proxyEnabled);
+
+  async function onSave(apply: boolean) {
+    assertValueDefined(config.proxyEnabled);
+    if (!apply) {
+      setValue(config.proxyEnabled);
+      return NOOP;
+    }
+    if (config.proxyEnabled == value()) return NOOP;
+    config.proxyEnabled = value();
+    await setKey("config_proxyEnabled", config.proxyEnabled ? "true" : "false");
+    return NOOP;
+  }
+
+  createEffect(() => {
+    value();
+    onSave(true);
+  });
+
+  return [
+    function UI() {
+      return (
+        <FormControl id="proxyEnabled">
+          <FormLabel>{locale.get("SETTING_PROXY_ENABLED")}</FormLabel>
+          <Box>
+            <Checkbox
+              checked={value()}
+              size="md"
+              onChange={() => setValue(x => !x)}
+            >
+              {locale.get("SETTING_ENABLED")}
+            </Checkbox>
+          </Box>
+        </FormControl>
+      );
+    },
+  ] as const;
+}

--- a/src/config/proxy-host.tsx
+++ b/src/config/proxy-host.tsx
@@ -1,0 +1,72 @@
+import {
+  createIcon,
+  FormControl,
+  FormLabel,
+  Input,
+  InputGroup
+} from "@hope-ui/solid";
+import { createEffect, createSignal } from "solid-js";
+import { Locale } from "../locale";
+import { Config, NOOP } from "./config-def";
+import { assertValueDefined, getKey, setKey } from "@utils";
+
+declare module "./config-def" {
+  interface Config {
+    proxyHost: string;
+  }
+}
+
+export async function createProxyHostConfig({
+  config,
+  locale,
+}: {
+  config: Partial<Config>;
+  locale: Locale;
+}) {
+  try {
+    config.proxyHost = await getKey("config_proxyHost");
+  } catch {
+    config.proxyHost = "127.0.0.1:8080"; // default value
+  }
+
+  const [value, setValue] = createSignal(config.proxyHost);
+
+  async function onSave(apply: boolean) {
+    assertValueDefined(config.proxyHost);
+    if (!apply) {
+      setValue(config.proxyHost);
+      return NOOP;
+    }
+    if (config.proxyHost == value()) return NOOP;
+    config.proxyHost = value();
+    await setKey("config_proxyHost", config.proxyHost);
+    return NOOP;
+  }
+
+  createEffect(() => {
+    value();
+    onSave(true);
+  });
+
+  return [
+    function UI() {
+      return (
+        <FormControl id="proxyHost">
+          <FormLabel>{locale.get("SETTING_PROXY_HOST")}</FormLabel>
+          <InputGroup>
+            <Input value={value()} onChange={(e) => setValue(e.target.value)} />
+          </InputGroup>
+          {/*<Box>*/}
+          {/*  <Checkbox*/}
+          {/*    checked={value()}*/}
+          {/*    size="md"*/}
+          {/*    onChange={() => setValue(x => !x)}*/}
+          {/*  >*/}
+          {/*    {locale.get("SETTING_ENABLED")}*/}
+          {/*  </Checkbox>*/}
+          {/*</Box>*/}
+        </FormControl>
+      );
+    },
+  ] as const;
+}

--- a/src/config/proxy-host.tsx
+++ b/src/config/proxy-host.tsx
@@ -56,15 +56,6 @@ export async function createProxyHostConfig({
           <InputGroup>
             <Input value={value()} onChange={(e) => setValue(e.target.value)} />
           </InputGroup>
-          {/*<Box>*/}
-          {/*  <Checkbox*/}
-          {/*    checked={value()}*/}
-          {/*    size="md"*/}
-          {/*    onChange={() => setValue(x => !x)}*/}
-          {/*  >*/}
-          {/*    {locale.get("SETTING_ENABLED")}*/}
-          {/*  </Checkbox>*/}
-          {/*</Box>*/}
         </FormControl>
       );
     },

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -1,4 +1,5 @@
 import { zh_CN } from "./zh_CN";
+import { en } from "@locale/en";
 
 export const de_DE: typeof zh_CN = {
   CONTENT_LANG_ID: "de-de",
@@ -114,4 +115,8 @@ export const de_DE: typeof zh_CN = {
     "Aktuelle version als gemeindeversion, die nicht offiziell unterstützt wird. Bitte berichten sie nicht über Fragen.",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+
+  SETTING_PROXY_ENABLED: en.SETTING_PROXY_ENABLED, // TODO: Translate
+  SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
+  SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 };

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -112,4 +112,9 @@ export const en: typeof zh_CN = {
     "The current selection is the Community version, this version is not officially supported, please do not report any issues",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+
+  SETTING_PROXY_ENABLED: "Enable HTTP Proxy",
+  SETTING_PROXY_HOST: "HTTP Proxy Host",
+  SETTING_PROXY_DESC:
+    "The proxy only applies to the game, not to the whole launcher.",
 };

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -110,4 +110,9 @@ export const es_ES: typeof zh_CN = {
   COMMUNITY_WINE_ALERT: en.COMMUNITY_WINE_ALERT,
 
   SETTING_BLOCK_NET: en.SETTING_BLOCK_NET,
+
+  SETTING_PROXY_ENABLED: "Activar Proxy HTTP",
+  SETTING_PROXY_HOST: "Host del Proxy HTTP",
+  SETTING_PROXY_DESC:
+    "El proxy solo se aplica al juego, y no al launcher entero", // TODO: Translate
 };

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -1,4 +1,5 @@
 import { zh_CN } from "./zh_CN";
+import { en } from "@locale/en";
 
 export const fr_FR: typeof zh_CN = {
   CONTENT_LANG_ID: "fr-fr",
@@ -116,4 +117,8 @@ export const fr_FR: typeof zh_CN = {
     "La sélection actuelle est la version communautaire, cette version n’est pas officiellement prise en charge, veuillez ne pas signaler de problèmes",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+
+  SETTING_PROXY_ENABLED: en.SETTING_PROXY_ENABLED, // TODO: Translate
+  SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
+  SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 };

--- a/src/locale/ko_KR.ts
+++ b/src/locale/ko_KR.ts
@@ -1,4 +1,5 @@
 import { zh_CN } from "./zh_CN";
+import { en } from "@locale/en";
 
 export const ko_KR: typeof zh_CN = {
   CONTENT_LANG_ID: "ko-kr",
@@ -112,4 +113,8 @@ export const ko_KR: typeof zh_CN = {
     "현재 커뮤니티 버전이 선택되었습니다.이 버전은 공식적으로 지원되지 않습니다. 보고하지 마십시오",
 
   SETTING_BLOCK_NET: "게임실행 문제해결(hosts 수정)",
+
+  SETTING_PROXY_ENABLED: en.SETTING_PROXY_ENABLED, // TODO: Translate
+  SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
+  SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 };

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -112,4 +112,8 @@ export const ru_RU: typeof zh_CN = {
     "В настоящее время выбрана версия сообщества, эта версия официально не поддерживается, не сообщайте о каких - либо проблемах",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+
+  SETTING_PROXY_ENABLED: en.SETTING_PROXY_ENABLED, // TODO: Translate
+  SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
+  SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 };

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -113,4 +113,8 @@ export const vi_VN: typeof zh_CN = {
     "Hiện tại được chọn là phiên bản cộng đồng, phiên bản này không được hỗ trợ chính thức, vui lòng không báo cáo bất kỳ vấn đề nào",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+
+  SETTING_PROXY_ENABLED: en.SETTING_PROXY_ENABLED, // TODO: Translate
+  SETTING_PROXY_HOST: en.SETTING_PROXY_HOST, // TODO: Translate
+  SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 };

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -107,4 +107,9 @@ export const zh_CN = {
     "当前选择为社区版本，此版本不受官方支持，请不要报告任何问题",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+
+  SETTING_PROXY_ENABLED: "Enable HTTP Proxy", // TODO: Translate
+  SETTING_PROXY_HOST: "HTTP Proxy Host", // TODO: Translate
+  SETTING_PROXY_DESC:
+    "The proxy only applies to the game, not to the whole launcher.", // TODO: Translate
 };


### PR DESCRIPTION
The title says it all.

It adds two extra options (Enable Proxy and Proxy Host) to the General settings menu. The proxy only applies to the games, not the whole launcher.  (this is also clarified with a little note in the settings menu)

English and Spanish translations included. All other languages are not translated, as I know none of them. If anyone wants to add them, comment here and I'll do it.

If this needs any edits, let me know, and I'll be more than happy to make them.

Screenshot of the new options:
<img width="1392" height="842" alt="image" src="https://github.com/user-attachments/assets/12eeee82-5b3c-4ff1-a774-f6ad5edf22c1" />
