### PR TITLE
Fix the 10010-4001 and 15-4001 errors

### DIFF
--- a/src/clients/mhy/hk4e/program-launch-game.ts
+++ b/src/clients/mhy/hk4e/program-launch-game.ts
@@ -37,27 +37,6 @@ export async function* launchGameProgram({
 
   await wine.setProps(config);
 
-  const cmd = `@echo off
-cd "%~dp0"
-copy "${wine.toWinePath(
-    join(gameDir, atob("SG9Zb0tQcm90ZWN0LnN5cw=="))
-  )}" "%WINDIR%\\system32\\"
-cd /d "${wine.toWinePath(gameDir)}"
-${await (async () => {
-  if (config.fpsUnlock !== "default") {
-    return `"${wine.toWinePath(
-      resolve("./fpsunlock/genshin-force-fps.exe")
-    )}" -f ${config.fpsUnlock} -o "${wine.toWinePath(
-      join(gameDir, gameExecutable)
-    )}"`;
-  } else {
-    return `"${wine.toWinePath(join(gameDir, gameExecutable))}"${
-      /* workaround 10351-4001 */
-      " -platform_type CLOUD_THIRD_PARTY_PC -is_cloud 1"
-    }`;
-  }
-})()}`;
-  await writeFile(resolve("config.bat"), cmd);
   yield* patchProgram(gameDir, wine, server, config);
   await mkdirp(resolve("./logs"));
   const yaaglDir = resolve("./");
@@ -99,8 +78,10 @@ ${await (async () => {
     }
 
     await wine.exec2(
-      "cmd",
-      ["/c", `${wine.toWinePath(resolve("./config.bat"))}`],
+      "C:\\windows\\system32\\steam.exe",
+      [wine.toWinePath(join(gameDir, gameExecutable))],
+      // "cmd",
+      // ["/c", `${wine.toWinePath(resolve("./config.bat"))}`],
       {
         MTL_HUD_ENABLED: config.metalHud ? "1" : "",
         ...(wine.attributes.renderBackend == "gptk"

--- a/src/clients/mhy/patch.ts
+++ b/src/clients/mhy/patch.ts
@@ -78,6 +78,7 @@ export async function* patchProgram(
     );
   }
   const system32Dir = join(wine.prefix, "drive_c", "windows", "system32");
+  const syswow64Dir = join(wine.prefix, "drive_c", "windows", "syswow64");
   if (wine.attributes.renderBackend == "dxvk") {
     for (const f of DXVK_FILES) {
       await forceMove(join(system32Dir, f), join(system32Dir, f + ".bak"));
@@ -112,6 +113,12 @@ export async function* patchProgram(
       join(gameDir, "d3dcompiler_47.dll")
     );
   }
+
+  await cp(resolve("./sidecar/protonextras/steam32.exe"), join(system32Dir, "steam.exe"))
+  await cp(resolve("./sidecar/protonextras/steam64.exe"), join(syswow64Dir, "steam.exe"))
+  await cp(resolve("./sidecar/protonextras/lsteamclient32.dll"), join(system32Dir, "lsteamclient.dll"))
+  await cp(resolve("./sidecar/protonextras/lsteamclient64.dll"), join(syswow64Dir, "lsteamclient.dll"))
+
   setKey("patched", "1");
 }
 

--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -122,6 +122,7 @@ export async function createConfiguration({
                 <Show when={advanceSetting()}>
                   <Tab>{locale.get("SETTING_ADVANCED")}</Tab>
                 </Show>
+                <Tab>{locale.get("SETTING_LICENSES")}</Tab>
               </TabList>
               <TabPanel flex={1} pt={0} pb={0}>
                 <HStack spacing={"$4"} h="100%">
@@ -233,6 +234,47 @@ export async function createConfiguration({
                   </VStack>
                 </TabPanel>
               </Show>
+              <TabPanel flex={1} pt={0} pb={0} h="100%">
+                <VStack spacing={"$4"} w="100%" alignItems="start">
+                  <Heading>Copyright Notice: steam.exe and libsteamclient.dll (in the sidecar folder)</Heading>
+                  <Text>Copyright (c) 2015, 2019, 2020, 2021, 2022 Valve Corporation</Text>
+                  <Text>All rights reserved.</Text>
+                  <Text>
+                    Redistribution and use in source and binary forms, with or without modification,
+                    are permitted provided that the following conditions are met:
+                  </Text>
+
+                  <Text>
+                    1. Redistributions of source code must retain the above copyright notice, this
+                    list of conditions and the following disclaimer.
+                  </Text>
+
+                  <Text>
+                    2. Redistributions in binary form must reproduce the above copyright notice,
+                    this list of conditions and the following disclaimer in the documentation and/or
+                    other materials provided with the distribution.
+                  </Text>
+
+                  <Text>
+                    3. Neither the name of the copyright holder nor the names of its contributors
+                    may be used to endorse or promote products derived from this software without
+                    specific prior written permission.
+                  </Text>
+
+                  <Text>
+                    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+                    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+                    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+                    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+                    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+                    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+                    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+                    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+                  </Text>
+                </VStack>
+              </TabPanel>
             </Tabs>
           </ModalBody>
         </ModalContent>

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -1,4 +1,5 @@
 import { zh_CN } from "./zh_CN";
+import { en } from "@locale/en";
 
 export const de_DE: typeof zh_CN = {
   CONTENT_LANG_ID: "de-de",
@@ -114,4 +115,5 @@ export const de_DE: typeof zh_CN = {
     "Aktuelle version als gemeindeversion, die nicht offiziell unterstützt wird. Bitte berichten sie nicht über Fragen.",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+  SETTING_LICENSES: en.SETTING_LICENSES,
 };

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -112,4 +112,5 @@ export const en: typeof zh_CN = {
     "The current selection is the Community version, this version is not officially supported, please do not report any issues",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+  SETTING_LICENSES: "Licenses",
 };

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -110,4 +110,5 @@ export const es_ES: typeof zh_CN = {
   COMMUNITY_WINE_ALERT: en.COMMUNITY_WINE_ALERT,
 
   SETTING_BLOCK_NET: en.SETTING_BLOCK_NET,
+  SETTING_LICENSES: "Licencias",
 };

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -1,4 +1,5 @@
 import { zh_CN } from "./zh_CN";
+import { en } from "@locale/en";
 
 export const fr_FR: typeof zh_CN = {
   CONTENT_LANG_ID: "fr-fr",
@@ -116,4 +117,5 @@ export const fr_FR: typeof zh_CN = {
     "La sélection actuelle est la version communautaire, cette version n’est pas officiellement prise en charge, veuillez ne pas signaler de problèmes",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+  SETTING_LICENSES: en.SETTING_LICENSES,
 };

--- a/src/locale/ko_KR.ts
+++ b/src/locale/ko_KR.ts
@@ -1,4 +1,5 @@
 import { zh_CN } from "./zh_CN";
+import { en } from "@locale/en";
 
 export const ko_KR: typeof zh_CN = {
   CONTENT_LANG_ID: "ko-kr",
@@ -112,4 +113,5 @@ export const ko_KR: typeof zh_CN = {
     "현재 커뮤니티 버전이 선택되었습니다.이 버전은 공식적으로 지원되지 않습니다. 보고하지 마십시오",
 
   SETTING_BLOCK_NET: "게임실행 문제해결(hosts 수정)",
+  SETTING_LICENSES: en.SETTING_LICENSES,
 };

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -112,4 +112,5 @@ export const ru_RU: typeof zh_CN = {
     "В настоящее время выбрана версия сообщества, эта версия официально не поддерживается, не сообщайте о каких - либо проблемах",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+  SETTING_LICENSES: en.SETTING_LICENSES,
 };

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -113,4 +113,5 @@ export const vi_VN: typeof zh_CN = {
     "Hiện tại được chọn là phiên bản cộng đồng, phiên bản này không được hỗ trợ chính thức, vui lòng không báo cáo bất kỳ vấn đề nào",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+  SETTING_LICENSES: en.SETTING_LICENSES,
 };

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -107,4 +107,5 @@ export const zh_CN = {
     "当前选择为社区版本，此版本不受官方支持，请不要报告任何问题",
 
   SETTING_BLOCK_NET: "Launch Fix(block hosts)",
+  SETTING_LICENSES: "Licenses",
 };


### PR DESCRIPTION
This fixes the 15-4001 and 10010-4001 erors that have recently been experienced in hk4e.

This makes several changes:
- `config.bat` is no longer generated for hk4e. This means that:
  - FPS Unlocker no longer works. (UI still there, but no longer works)
- It adds the `protonextras`to the `sidecar` dir. These are the executables needed to make it all work
- It adds a Licenses section to the settings, as we can't ship Proton executables without it.
- Makes the Network Block irrelevant, as the game now runs normally.
- Adds new translation for the sidebar name of the "Licenses" tab in settings.
- Probably more stuff that I'm missing.

This is all to be fixed at a later date (especially FPS Unlocker and Network Block)