### PR TITLE
fix CN Sophon game updates

### DIFF
--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -705,7 +705,7 @@ class SophonClient:
 			if self.rel_type == "os":
 				url = "sg-downloader-api.ho" + "yoverse.com"
 			elif self.rel_type == "cn":
-				assert False, "TODO"
+				url = "api-takumi.mih" + "oyo.com"
 		else:
 			if self.rel_type == "os":
 				url = "sg-public-api.ho" + "yoverse.com"


### PR DESCRIPTION
## Summary

- enable CN Genshin Sophon updates

## Root cause

The CN update path in `SophonClient.make_getBuild_url` was left as `assert False, "TODO"`. As a result, every CN update failed before requesting the patch manifest.

The CN Sophon API is served from `api-takumi.mihoyo.com`, while the existing OS update endpoint uses `sg-downloader-api.hoyoverse.com`.

## Validation

- `python3 -m py_compile sophon_server/sophon_api.py sophon_server/tasks.py sophon_server/server.py sophon_server/models.py`
- `git diff --check`
- Verified the live CN `getPatchBuild` endpoint returns a successful response for the current branch metadata.

Fixes #708
