### PR TITLE
fix: enable Sophon updates for CN

### DIFF
--- a/sophon_server/endpoints.py
+++ b/sophon_server/endpoints.py
@@ -1,0 +1,15 @@
+from typing import Literal
+
+
+def get_sophon_api_host(
+    do_update: bool, rel_type: Literal["os", "cn", "bb"]
+) -> str | None:
+    if rel_type == "cn":
+        return "api-takumi.mih" + "oyo.com"
+    if rel_type == "os":
+        return (
+            "sg-downloader-api.ho" + "yoverse.com"
+            if do_update
+            else "sg-public-api.ho" + "yoverse.com"
+        )
+    return None

--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -74,6 +74,7 @@ from google.protobuf.json_format import MessageToJson
 
 import manifest_pb2 # generated
 import manifest_ldiff_pb2 # generated
+from endpoints import get_sophon_api_host
 
 from io import BytesIO
 import pycurl
@@ -700,17 +701,7 @@ class SophonClient:
 			self.retrieve_API_keys()
 
 
-		url: str = None
-		if OPT.do_update:
-			if self.rel_type == "os":
-				url = "sg-downloader-api.ho" + "yoverse.com"
-			elif self.rel_type == "cn":
-				assert False, "TODO"
-		else:
-			if self.rel_type == "os":
-				url = "sg-public-api.ho" + "yoverse.com"
-			elif self.rel_type == "cn":
-				url = "api-takumi.mih" + "oyo.com"
+		url = get_sophon_api_host(OPT.do_update, self.rel_type)
 
 		assert not (url is None), f"Unhandled release type {self.rel_type}"
 

--- a/sophon_server/test_sophon_api.py
+++ b/sophon_server/test_sophon_api.py
@@ -1,0 +1,25 @@
+import unittest
+
+from endpoints import get_sophon_api_host
+
+
+class GetSophonApiHostTest(unittest.TestCase):
+    def test_cn_update_uses_takumi_patch_endpoint(self):
+        self.assertEqual(get_sophon_api_host(True, "cn"), "api-takumi.mihoyo.com")
+
+    def test_overseas_update_keeps_downloader_patch_endpoint(self):
+        self.assertEqual(
+            get_sophon_api_host(True, "os"), "sg-downloader-api.hoyoverse.com"
+        )
+
+    def test_cn_full_download_uses_takumi_endpoint(self):
+        self.assertEqual(get_sophon_api_host(False, "cn"), "api-takumi.mihoyo.com")
+
+    def test_overseas_full_download_keeps_public_endpoint(self):
+        self.assertEqual(
+            get_sophon_api_host(False, "os"), "sg-public-api.hoyoverse.com"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- use the CN Sophon API host for `getPatchBuild` instead of aborting with `TODO`
- centralize Sophon endpoint selection
- add regression coverage for CN/OS update and full-download endpoints

## Testing

- `/opt/homebrew/bin/python3.13 -m unittest -v test_sophon_api.py`
- `/opt/homebrew/bin/python3.13 -m py_compile endpoints.py test_sophon_api.py sophon_api.py`
- verified the CN `getPatchBuild` endpoint returns a valid patch manifest
- verified by completing a CN game update with this fix

This PR intentionally excludes the separate ARM/Neutralino build changes.
