### PR TITLE
feat: microphone permission, configurable borderless windowing & stop game button

### DIFF
--- a/build-app.js
+++ b/build-app.js
@@ -330,6 +330,8 @@ PATH_LAUNCH="$(dirname "$CONTENTS_DIR")" exec "$SCRIPT_DIR/${appname}" --path="$
             <key>NSAllowsArbitraryLoads</key>
             <true/>
         </dict>
+        <key>NSMicrophoneUsageDescription</key>
+        <string>Yaagl requires microphone access for in-game voice chat.</string>
     </dict>
     </plist>`
   );

--- a/src/app.css
+++ b/src/app.css
@@ -59,6 +59,20 @@ body {
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
 }
 
+.launch-button-running .stop-button {
+  background-color: #5c6068 !important;
+  color: #ffffff !important;
+}
+
+.launch-button-running .stop-button:hover {
+  background-color: #6c717a !important;
+}
+
+.launch-button-running .settings-button {
+  background-color: #4d5057 !important;
+  color: rgba(255, 255, 255, 0.4) !important;
+}
+
 ::-webkit-scrollbar {
   height: 16px;
   overflow: visible;

--- a/src/clients/mhy/hk4e/config/borderless.tsx
+++ b/src/clients/mhy/hk4e/config/borderless.tsx
@@ -1,0 +1,65 @@
+import { FormControl, FormLabel, Box, Checkbox } from "@hope-ui/solid";
+import { createEffect, createSignal } from "solid-js";
+import { Locale } from "@locale";
+import { assertValueDefined, getKey, setKey } from "@utils";
+import { Config, NOOP } from "@config/config-def";
+
+declare module "@config/config-def" {
+  interface Config {
+    borderlessWindow: boolean;
+  }
+}
+
+const CONFIG_KEY = "config_hk4e_borderless_window";
+
+export async function createBorderlessWindowConfig({
+  locale,
+  config,
+}: {
+  config: Partial<Config>;
+  locale: Locale;
+}) {
+  try {
+    config.borderlessWindow = (await getKey(CONFIG_KEY)) == "true";
+  } catch {
+    config.borderlessWindow = true; // default to true
+  }
+
+  const [value, setValue] = createSignal(config.borderlessWindow);
+
+  async function onSave(apply: boolean) {
+    assertValueDefined(config.borderlessWindow);
+    if (!apply) {
+      setValue(config.borderlessWindow);
+      return NOOP;
+    }
+    if (config.borderlessWindow == value()) return NOOP;
+    config.borderlessWindow = value();
+    await setKey(CONFIG_KEY, config.borderlessWindow ? "true" : "false");
+    return NOOP;
+  }
+
+  createEffect(() => {
+    value();
+    onSave(true);
+  });
+
+  return [
+    function UI() {
+      return (
+        <FormControl id="hk4eBorderlessWindow">
+          <FormLabel>{locale.get("SETTING_BORDERLESS_WINDOW")}</FormLabel>
+          <Box>
+            <Checkbox
+              checked={value()}
+              onChange={() => setValue(x => !x)}
+              size="md"
+            >
+              {locale.get("SETTING_ENABLED")}
+            </Checkbox>
+          </Box>
+        </FormControl>
+      );
+    },
+  ] as const;
+}

--- a/src/clients/mhy/hk4e/index.tsx
+++ b/src/clients/mhy/hk4e/index.tsx
@@ -46,6 +46,7 @@ import createBlockNet from "./config/block-net";
 import createResolution from "./config/resolution";
 import createTimeoutFix from "./config/timeout-fix";
 import { createEnableHDRConfig } from "./config/enable-hdr";
+import { createBorderlessWindowConfig } from "./config/borderless";
 import { getGameVersion } from "../unity";
 import {
   VoicePackNames,
@@ -303,12 +304,14 @@ export async function createHK4EChannelClient({
       const [HDR] = await createEnableHDRConfig({ locale, config });
       const [RES] = await createResolution({ locale, config });
       const [TF] = await createTimeoutFix({ locale, config });
+      const [BW] = await createBorderlessWindowConfig({ locale, config });
 
       return function () {
         return [
           "Game Version: ",
           gameCurrentVersion(),
           <HDR />,
+          <BW />,
           <W3 />,
           <PO />,
           <SP />,

--- a/src/clients/mhy/hk4e/program-launch-game.ts
+++ b/src/clients/mhy/hk4e/program-launch-game.ts
@@ -87,6 +87,32 @@ async function applyResolutionRegistry(
   }
 }
 
+async function applyBorderlessModeRegistry(wine: Wine, server: Server) {
+  let key = "HKEY_CURRENT_USER\\Software\\\x6d\x69\x48\x6f\x59\x6f\\";
+  if (server.id === "hk4e_cn") {
+    key += "\u539f\u795e";
+  } else if (server.id === "hk4e_global") {
+    key += "\x47\x65\x6e\x73\x68\x69\x6e\x20\x49\x6d\x70\x61\x63\x74";
+  } else {
+    return;
+  }
+
+  const lines = [
+    `Windows Registry Editor Version 5.00`,
+    ``,
+    `[${key}]`,
+    `"Screenmanager Is Fullscreen mode_h3981298716"=dword:00000000`,
+  ];
+
+  const path = resolve("./hk4e_borderless_mode.reg");
+  await writeBinary(path, utf16le(lines.join("\r\n")));
+  try {
+    await wine.exec("regedit", [wine.toWinePath(path)], {}, "/dev/null");
+  } finally {
+    await removeFile(path);
+  }
+}
+
 export async function* launchGameProgram({
   gameDir,
   gameExecutable,
@@ -108,11 +134,17 @@ export async function* launchGameProgram({
     await applyHDRRegistry({ wine, server });
   }
 
+  if (config.borderlessWindow !== false) {
+    await applyBorderlessModeRegistry(wine, server);
+  }
+
   if (config.resolutionCustom) {
     await applyResolutionRegistry(wine, server, config);
   }
   await wine.waitUntilServerOff();
 
+  const borderlessArgs =
+    config.borderlessWindow !== false ? " -screen-fullscreen 0 -popupwindow" : "";
   const cmd = `@echo off
 cd "%~dp0"
 copy "${wine.toWinePath(
@@ -121,7 +153,7 @@ copy "${wine.toWinePath(
 cd /d "${wine.toWinePath(gameDir)}"
 "${wine.toWinePath(
     join(gameDir, gameExecutable)
-  )}" -platform_type CLOUD_THIRD_PARTY_PC -is_cloud 1`;
+  )}" -platform_type CLOUD_THIRD_PARTY_PC -is_cloud 1${borderlessArgs}`;
   await writeFile(resolve("config.bat"), cmd);
   yield* patchProgram(gameDir, wine, server, config);
   await mkdirp(resolve("./logs"));
@@ -166,7 +198,12 @@ cd /d "${wine.toWinePath(gameDir)}"
     await wine.exec2(
       config.steamPatch ? "C:\\windows\\system32\\steam.exe" : "cmd",
       config.steamPatch
-        ? [wine.toWinePath(join(gameDir, gameExecutable))]
+        ? [
+            wine.toWinePath(join(gameDir, gameExecutable)),
+            ...(config.borderlessWindow !== false
+              ? ["-screen-fullscreen", "0", "-popupwindow"]
+              : []),
+          ]
         : ["/c", `${wine.toWinePath(resolve("./config.bat"))} `],
       {
         MTL_HUD_ENABLED: config.metalHud ? "1" : "",
@@ -192,6 +229,11 @@ cd /d "${wine.toWinePath(gameDir)}"
       },
       logfile
     );
+  } catch (e: unknown) {
+    // it seems game crashed?
+    await log(String(e));
+  } finally {
+    await wine.killServer();
     await wine.waitUntilServerOff();
     if (config.hk4eEnableHDR) {
       await revertHDRRegistry({ wine, server });
@@ -199,13 +241,9 @@ cd /d "${wine.toWinePath(gameDir)}"
     if (config.resolutionCustom) {
       await revertResolutionRegistry(wine, server);
     }
-  } catch (e: unknown) {
-    // it seems game crashed?
-    await log(String(e));
+    await removeFile(resolve("config.bat"));
   }
 
-  // await removeFile(resolve("bWh5cHJvdDJfcnVubmluZy5yZWcK.reg"));
-  await removeFile(resolve("config.bat"));
   yield ["setStateText", "REVERT_PATCHING"];
   yield* patchRevertProgram(gameDir, wine, server, config);
 }

--- a/src/launcher/index.tsx
+++ b/src/launcher/index.tsx
@@ -240,26 +240,38 @@ export async function createLauncher({
             >
               <PopoverTrigger as={Box}>
                 <ButtonGroup
-                  class="launch-button"
+                  class={`launch-button ${statusText() === locale.get("GAME_RUNNING") ? "launch-button-running" : ""}`}
                   size="xl"
                   attached
                   minWidth={150}
                 >
                   <Button
+                    class="stop-button"
                     mr="-1px"
-                    disabled={programBusy()}
-                    onClick={() => onButtonClick().catch(fatal)}
+                    disabled={programBusy() && statusText() !== locale.get("GAME_RUNNING")}
+                    colorScheme={statusText() === locale.get("GAME_RUNNING") ? "neutral" : "primary"}
+                    onClick={() => {
+                      if (statusText() === locale.get("GAME_RUNNING")) {
+                        wine.killServer().catch(fatal);
+                      } else {
+                        onButtonClick().catch(fatal);
+                      }
+                    }}
                   >
-                    {installState() == "INSTALLED"
-                      ? updateRequired()
-                        ? locale.get("UPDATE")
-                        : locale.get("LAUNCH")
-                      : locale.get("INSTALL")}
+                    {statusText() === locale.get("GAME_RUNNING")
+                      ? `✕ ${locale.get("STOP_GAME")}`
+                      : installState() == "INSTALLED"
+                        ? updateRequired()
+                          ? locale.get("UPDATE")
+                          : locale.get("LAUNCH")
+                        : locale.get("INSTALL")}
                   </Button>
                   <Show when={installState() == "INSTALLED"}>
                     <IconButton
+                      class="settings-button"
                       onClick={onOpen}
                       disabled={programBusy()}
+                      colorScheme={statusText() === locale.get("GAME_RUNNING") ? "neutral" : "primary"}
                       fontSize={30}
                       aria-label="Settings"
                       icon={<IconSetting />}

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -4,6 +4,7 @@ import { en } from "@locale/en";
 export const de_DE: typeof zh_CN = {
   CONTENT_LANG_ID: "de-de",
   LAUNCH: "Spiel starten",
+  STOP_GAME: "Stoppen",
   INSTALL: "Spiel installieren",
   UPDATING: "Aktualisieren",
   DOWNLOADING: "Herunterladen",
@@ -122,6 +123,7 @@ export const de_DE: typeof zh_CN = {
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
+  SETTING_BORDERLESS_WINDOW: en.SETTING_BORDERLESS_WINDOW,
 
   UPDATE_PROMPT_IGNORE: "Update ignorieren",
   SETTING_CHECK_UPDATE: "Nach YAAGL-Updates suchen",

--- a/src/locale/en.ts
+++ b/src/locale/en.ts
@@ -3,6 +3,7 @@ import { zh_CN } from "./zh_CN";
 export const en: typeof zh_CN = {
   CONTENT_LANG_ID: "en-us",
   LAUNCH: "Launch Game",
+  STOP_GAME: "Stop",
   INSTALL: "Install Game",
   UPDATING: "Updating",
   DOWNLOADING: "Downloading",
@@ -120,6 +121,8 @@ export const en: typeof zh_CN = {
     "The proxy only applies to the game, not to the whole launcher.",
 
   SETTING_TURN_ON_STEAM_PATCH: "Enable Steam Patch",
+  SETTING_BORDERLESS_WINDOW:
+    "Borderless Window (Prevent dock minimization on background switch)",
 
   UPDATE_PROMPT_IGNORE: "Ignore Update",
   SETTING_CHECK_UPDATE: "Check for YAAGL Updates",

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -4,6 +4,7 @@ import { zh_CN } from "./zh_CN";
 export const es_ES: typeof zh_CN = {
   CONTENT_LANG_ID: "es-es",
   LAUNCH: "Iniciar el juego",
+  STOP_GAME: "Detener",
   INSTALL: "Instalar el juego",
   UPDATING: "Actualizando",
   DOWNLOADING: "Descargando",
@@ -119,7 +120,8 @@ export const es_ES: typeof zh_CN = {
   SETTING_PROXY_DESC:
     "El proxy solo se aplica al juego, y no al launcher entero",
 
-  SETTING_TURN_ON_STEAM_PATCH: "Activar Parche de Steam",
+  SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH,
+  SETTING_BORDERLESS_WINDOW: en.SETTING_BORDERLESS_WINDOW,
 
   UPDATE_PROMPT_IGNORE: "Ignorar actualización",
   SETTING_CHECK_UPDATE: "Buscar actualizaciones de YAAGL",

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -4,6 +4,7 @@ import { en } from "@locale/en";
 export const fr_FR: typeof zh_CN = {
   CONTENT_LANG_ID: "fr-fr",
   LAUNCH: "Lancer le jeu",
+  STOP_GAME: "Arrêter",
   INSTALL: "Installer le jeu",
   UPDATING: "Mise à jour",
   DOWNLOADING: "Téléchargement",
@@ -124,6 +125,7 @@ export const fr_FR: typeof zh_CN = {
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
+  SETTING_BORDERLESS_WINDOW: en.SETTING_BORDERLESS_WINDOW,
 
   UPDATE_PROMPT_IGNORE: "Ignorer la mise à jour",
   SETTING_CHECK_UPDATE: "Rechercher des mises à jour YAAGL",

--- a/src/locale/ja_JP.ts
+++ b/src/locale/ja_JP.ts
@@ -3,6 +3,7 @@ import { zh_CN } from "./zh_CN";
 export const ja_JP: typeof zh_CN = {
   CONTENT_LANG_ID: "ja-jp",
   LAUNCH: "ゲーム開始",
+  STOP_GAME: "停止",
   INSTALL: "ゲームをインストール",
   UPDATING: "更新中",
   DOWNLOADING: "ダウンロード中",
@@ -121,6 +122,7 @@ export const ja_JP: typeof zh_CN = {
     "このプロキシ設定はゲームのみに適用され、ランチャー全体には適用されません。",
 
   SETTING_TURN_ON_STEAM_PATCH: "Steamパッチ有効",
+  SETTING_BORDERLESS_WINDOW: "ボーダーレスウィンドウ（最小化防止）",
 
   UPDATE_PROMPT_IGNORE: "更新無視",
   SETTING_CHECK_UPDATE: "YAAGL更新を確認する",

--- a/src/locale/ko_KR.ts
+++ b/src/locale/ko_KR.ts
@@ -4,6 +4,7 @@ import { en } from "@locale/en";
 export const ko_KR: typeof zh_CN = {
   CONTENT_LANG_ID: "ko-kr",
   LAUNCH: "게임 실행",
+  STOP_GAME: "중지",
   INSTALL: "게임 다운로드",
   UPDATING: "업데이트 중",
   DOWNLOADING: "다운로드 중",
@@ -120,6 +121,7 @@ export const ko_KR: typeof zh_CN = {
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
+  SETTING_BORDERLESS_WINDOW: en.SETTING_BORDERLESS_WINDOW,
 
   UPDATE_PROMPT_IGNORE: "업데이트 무시",
   SETTING_CHECK_UPDATE: "YAAGL 업데이트 확인",

--- a/src/locale/ru_RU.ts
+++ b/src/locale/ru_RU.ts
@@ -4,6 +4,7 @@ import { zh_CN } from "./zh_CN";
 export const ru_RU: typeof zh_CN = {
   CONTENT_LANG_ID: "ru-ru",
   LAUNCH: "Запустить игру",
+  STOP_GAME: "Остановить",
   INSTALL: "Установить игру",
   UPDATING: "Обновление",
   DOWNLOADING: "Загрузка",
@@ -121,6 +122,7 @@ export const ru_RU: typeof zh_CN = {
   SETTING_PROXY_DESC: "Прокси действует только на игру, а не на весь лаунчер.",
 
   SETTING_TURN_ON_STEAM_PATCH: "Использовать патч Steam",
+  SETTING_BORDERLESS_WINDOW: en.SETTING_BORDERLESS_WINDOW,
 
   UPDATE_PROMPT_IGNORE: "Пропустить обновление",
   SETTING_CHECK_UPDATE: "Проверить обновления YAAGL",

--- a/src/locale/th_TH.ts
+++ b/src/locale/th_TH.ts
@@ -4,6 +4,7 @@ import { en } from "@locale/en";
 export const th_TH: typeof zh_CN = {
   CONTENT_LANG_ID: "th-th",
   LAUNCH: "เริ่มเกม",
+  STOP_GAME: "หยุด",
   INSTALL: "ติดตั้งเกม",
   UPDATING: "กำลังอัปเดต",
   DOWNLOADING: "กำลังดาวน์โหลด",
@@ -118,6 +119,7 @@ export const th_TH: typeof zh_CN = {
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
+  SETTING_BORDERLESS_WINDOW: en.SETTING_BORDERLESS_WINDOW,
 
   UPDATE_PROMPT_IGNORE: "ละเว้นการอัปเดต",
   SETTING_CHECK_UPDATE: "ตรวจสอบการอัปเดต YAAGL",

--- a/src/locale/vi_VN.ts
+++ b/src/locale/vi_VN.ts
@@ -4,6 +4,7 @@ import { zh_CN } from "./zh_CN";
 export const vi_VN: typeof zh_CN = {
   CONTENT_LANG_ID: "vi-vn",
   LAUNCH: "Khởi động trò chơi",
+  STOP_GAME: "Dừng",
   INSTALL: "Cài đặt trò chơi",
   UPDATING: "Đang cập nhật",
   DOWNLOADING: "Đang tải",
@@ -120,6 +121,7 @@ export const vi_VN: typeof zh_CN = {
   SETTING_PROXY_DESC: en.SETTING_PROXY_DESC, // TODO: Translate
 
   SETTING_TURN_ON_STEAM_PATCH: en.SETTING_TURN_ON_STEAM_PATCH, // TODO: Translate
+  SETTING_BORDERLESS_WINDOW: en.SETTING_BORDERLESS_WINDOW,
 
   UPDATE_PROMPT_IGNORE: "Bỏ qua cập nhật",
   SETTING_CHECK_UPDATE: "Kiểm tra cập nhật YAAGL",

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -3,6 +3,7 @@ import { SuppportedContentLangId } from "./supported-content-lang-id";
 export const zh_CN = {
   CONTENT_LANG_ID: "zh-cn" as SuppportedContentLangId,
   LAUNCH: "开始游戏",
+  STOP_GAME: "停止",
   INSTALL: "安装游戏",
   UPDATING: "正在更新",
   DOWNLOADING: "正在下载",
@@ -115,6 +116,7 @@ export const zh_CN = {
     "The proxy only applies to the game, not to the whole launcher.", // TODO: Translate
 
   SETTING_TURN_ON_STEAM_PATCH: "Enable Steam Patch", // TODO: Translate
+  SETTING_BORDERLESS_WINDOW: "无边框窗口化（防止切后台最小化）",
 
   UPDATE_PROMPT_IGNORE: "忽略此更新",
   SETTING_CHECK_UPDATE: "检查 YAAGL 更新",

--- a/src/wine/wine.ts
+++ b/src/wine/wine.ts
@@ -69,6 +69,12 @@ export async function createWine(options: {
     });
   }
 
+  async function killServer() {
+    return await unixExec2([join(dirname(loaderBin), "wineserver"), "-k"], {
+      ...getEnvironmentVariables(),
+    });
+  }
+
   function toWinePath(absPath: string) {
     return "Z:" + `${absPath}`.replaceAll("/", "\\");
   }
@@ -125,6 +131,8 @@ reg add "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver" /v RetinaMode /t REG_SZ 
 reg add "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver" /v LeftCommandIsCtrl /t REG_SZ /d ${
       props.leftCmd ? "y" : "n"
     } /f
+reg add "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver" /v CaptureDisplaysForFullscreen /t REG_SZ /d n /f
+reg add "HKEY_CURRENT_USER\\Software\\Wine\\Mac Driver" /v WindowsMinimizeWhenFocusLost /t REG_SZ /d n /f
 `;
     await writeFile(resolve("winedrv_config.bat"), cmd);
     await exec(
@@ -157,6 +165,7 @@ reg add "HKEY_LOCAL_MACHINE\\SOFTWARE\\NVIDIA Corporation\\Global\\NGXCore" /v F
     exec,
     exec2,
     waitUntilServerOff,
+    killServer,
     cmd,
     toWinePath,
     prefix: options.prefix,


### PR DESCRIPTION
### Summary of Changes

This PR resolves issues affecting in-game voice communication, window multitasking, and process teardown on macOS:

1. **Microphone Permission Support:**
   - Adds `NSMicrophoneUsageDescription` to the `Info.plist` template in `build-app.js`.
   - Allows macOS TCC to properly display the system microphone permission prompt when the game initializes audio input (e.g. for in-game voice chat / 千星奇域).

2. **Configurable Borderless Window Mode:**
   - Adds a configurable setting `无边框窗口化（防止切后台最小化）` / `Borderless Window` with full 10-language localization.
   - Configures Wine Mac Driver registry keys (`CaptureDisplaysForFullscreen = n`, `WindowsMinimizeWhenFocusLost = n`) and sets `Screenmanager Is Fullscreen mode = 0` with `-screen-fullscreen 0 -popupwindow` to prevent the game window from minimizing into the macOS Dock when switching apps (`Cmd+Tab`).

3. **Interactive Stop Game Button & Clean Prefix Teardown:**
   - Implements a Steam-style neutral **`✕ 停止` / `✕ Stop`** button on the launcher interface while the game is running.
   - Allows users to cleanly and safely terminate the Wine prefix with one click if the game freezes during DLL teardown on exit.
   - Adds `wineserver -k` inside a `finally` block in the launcher lifecycle to ensure lingering helper processes (like `ZFGameBrowser.exe`) and Wine subsystem daemons are cleanly terminated when the game process finishes.

*(Note: Sophon manifest cache fixes are excluded from this PR to avoid overlap with open PR #727).*

### Verification
- Tested with Genshin Impact CN (`hk4ecn`) on macOS Apple Silicon.
- Verified microphone permission prompt and working in-game voiceover.
- Verified smooth `Cmd+Tab` app switching without dock minimization.
- Verified interactive Stop button and clean Wine prefix teardown.