### PR TITLE
fix(sophon): two download integrity bugs

### DIFF
--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -304,6 +304,15 @@ def get_game_version(game_data_dir: pathlib.Path, offset: int = 0x88) -> Optiona
 		return str_val.split('_')[0]
 
 
+def temp_name_for(relative_filename: str) -> str:
+	"""
+	Collision-free temporary name for a game file. Base names are not unique
+	within a manifest, so mix in a digest of the full relative path.
+	"""
+	digest = hashlib.md5(relative_filename.encode("utf-8")).hexdigest()[:16]
+	return digest + "_" + pathlib.Path(relative_filename).name
+
+
 # -------------------
 
 class DownloadInfo:
@@ -956,7 +965,7 @@ class SophonClient:
 			return
 
 		# Download to the temporary directory. Move after we're done.
-		dstfile = tempdir(filename.name)
+		dstfile = tempdir(temp_name_for(file_info.filename))
 		bytes_written = 0
 
 		while True: # run once
@@ -1223,7 +1232,7 @@ class SophonClient:
 		gamefile = gamedir(v.filename)
 
 		# Patched file goes into the temporary directory (at first)
-		dstfile = tempdir(pathlib.Path(v.filename).name)
+		dstfile = tempdir(temp_name_for(v.filename))
 		dstfile.unlink(True)  # remove any existing duplicate temporary file
 
 		ldiffname = ldiff_dir.joinpath(pinfo.patch_id)

--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -945,12 +945,17 @@ class SophonClient:
 		filename_safety_check(file_info.filename)
 		filename = pathlib.Path(file_info.filename) # "UnityGame_Data/Subdirectory/file.txt"
 
-		# Check whether the file already exists
-		if try_get_file_size(gamedir(filename)) == file_info.size:
-			if install_progress_handler:
-				install_progress_handler.file_download_skipped(file_info.filename, "exists")
-			#infolog(f"File '{filename.name}' already exists. ")
-			return True
+		# Check whether the file already exists.
+		# A file queued in `new_files_to_download` is there because the caller
+		# already found it wrong (repair md5 mismatch, failed patch). Its size can
+		# still match, so a size-only check would skip the files we were asked to
+		# restore.
+		if file_info.filename not in self.new_files_to_download:
+			if try_get_file_size(gamedir(filename)) == file_info.size:
+				if install_progress_handler:
+					install_progress_handler.file_download_skipped(file_info.filename, "exists")
+				#infolog(f"File '{filename.name}' already exists. ")
+				return True
 
 		CHUNK_URL_PREFIX = self.di_chunks.category_json["chunk_download"]["url_prefix"]
 


### PR DESCRIPTION
Two bugs in the sophon downloader, both hit while updating HSR but neither specific to it.

**Colliding temp file names.** Downloads are staged in the temp dir under the file's base name, and `diff_download_new_files` runs them on a thread pool. Base names are not unique in a manifest — HSR ships 46 `VFS.bytes` and 19 `AudioGround.bytes` — so two workers wrote to the same staging path and each moved the other's bytes into place. An update left files holding another file's content.

**Repair cannot replace same-size corruption.** `repair_by_category` hashes every file and queues md5 mismatches, but `download_game_file` returns early whenever the size on disk matches the manifest. A file corrupted in place usually keeps its size, so reliable repair detected those files and then skipped them. On my install a full integrity check left 64 files untouched.

Fixes: derive the staging name from the full relative path, and keep the size-based early exit only for files nobody queued.

Verified on HSR 4.5.0 OS: a repair after these changes replaced all 64 files and the game starts.