### PR TITLE
feat(hkrpg): download HSR through sophon

### DIFF
--- a/build-app.js
+++ b/build-app.js
@@ -36,11 +36,13 @@ const { IconIcns } = require("@shockpkg/icon-encoder");
       bundleId = config.applicationId + ".hkrpg.cn";
       appDistributionName = config.cli.binaryName + " HSR";
       config.modes.window.icon = "/src/icons/March7th.cr.png";
+      includeSophon = true;
       break;
     case "hkrpgos":
       bundleId = config.applicationId + ".hkrpg.os";
       appDistributionName = config.cli.binaryName + " HSR OS";
       config.modes.window.icon = "/src/icons/March7th.cr.png";
+      includeSophon = true;
       break;
     case "bh3glb":
       bundleId = config.applicationId + ".bh3.glb";

--- a/sophon_server/models.py
+++ b/sophon_server/models.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Literal
 
 class GameOperationRequest(BaseModel):
     gamedir: str
-    game_type: Literal["hk4e", "nap"]
+    game_type: Literal["hk4e", "nap", "hkrpg"]
     tempdir: Optional[str] = None
 
 class InstallRequest(GameOperationRequest):
@@ -30,7 +30,7 @@ class TaskStatus(BaseModel):
 
 
 class OnlineGameInfo(BaseModel):
-    game_type: Literal["hk4e", "nap", ""]   # "" is for handling error cases
+    game_type: Literal["hk4e", "nap", "hkrpg", ""]   # "" is for handling error cases
     version: str
     install_size: int
     updatable_versions: List[str]

--- a/sophon_server/server.py
+++ b/sophon_server/server.py
@@ -91,7 +91,7 @@ async def cancel_task(task_id: str):
     return {"message": f"Task {task_id} cancelled"}
 
 @app.get("/api/game/online_info")
-async def get_online_game_info(reltype: str, game: Literal["nap", "hk4e"]) -> OnlineGameInfo:
+async def get_online_game_info(reltype: str, game: Literal["nap", "hk4e", "hkrpg"]) -> OnlineGameInfo:
     return fetch_online_game_info(reltype, game)
 
 @app.get("/health")

--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -304,6 +304,15 @@ def get_game_version(game_data_dir: pathlib.Path, offset: int = 0x88) -> Optiona
 		return str_val.split('_')[0]
 
 
+def temp_name_for(relative_filename: str) -> str:
+	"""
+	Collision-free temporary name for a game file. Base names are not unique
+	within a manifest, so mix in a digest of the full relative path.
+	"""
+	digest = hashlib.md5(relative_filename.encode("utf-8")).hexdigest()[:16]
+	return digest + "_" + pathlib.Path(relative_filename).name
+
+
 # -------------------
 
 class DownloadInfo:
@@ -956,7 +965,7 @@ class SophonClient:
 			return
 
 		# Download to the temporary directory. Move after we're done.
-		dstfile = tempdir(filename.name)
+		dstfile = tempdir(temp_name_for(file_info.filename))
 		bytes_written = 0
 
 		while True: # run once
@@ -1223,7 +1232,7 @@ class SophonClient:
 		gamefile = gamedir(v.filename)
 
 		# Patched file goes into the temporary directory (at first)
-		dstfile = tempdir(pathlib.Path(v.filename).name)
+		dstfile = tempdir(temp_name_for(v.filename))
 		dstfile.unlink(True)  # remove any existing duplicate temporary file
 
 		ldiffname = ldiff_dir.joinpath(pinfo.patch_id)

--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -124,7 +124,7 @@ class Options(argparse.Namespace):
 	force_use_cache: bool = False # True: disallow downloads, False: download if not cached
 	predownload: bool = False
 	install_reltype: str | None = None
-	game_type: Literal["hk4e", "nap"] | None # hk4e or nap
+	game_type: Literal["hk4e", "nap", "hkrpg"] | None # hk4e, nap or hkrpg
 	do_install: bool = False
 	do_update: bool = False         # True: ldiff, False: chunks
 	repair_mode: str | None = None  # "quick"|"reliable"|None
@@ -143,6 +143,14 @@ OPT = Options()
 
 
 # ------------------- Translate between voiceover pack names
+# HSR keeps its voiceover packs in directories named after the language
+HKRPG_VOICEOVER_DIRS = {
+	"Chinese(PRC)": "zh-cn",
+	"English":      "en-us",
+	"Japanese":     "ja-jp",
+	"Korean":       "ko-kr",
+}
+
 VOICEOVERS_LUT = {
 	# "Friendly/short": {"short": "aa-bb", "friendly": "Longname"}
 	"English(US)": {"short": "en-us"},
@@ -306,11 +314,32 @@ def get_game_version(game_data_dir: pathlib.Path, offset: int = 0x88) -> Optiona
 
 def temp_name_for(relative_filename: str) -> str:
 	"""
-	Collision-free temporary name for a game file. Base names are not unique
-	within a manifest, so mix in a digest of the full relative path.
+	Collision-free temporary file name for a game file.
+	Base names are not unique within a manifest, so mix in a digest of the
+	full relative path while keeping the readable name for logs.
 	"""
 	digest = hashlib.md5(relative_filename.encode("utf-8")).hexdigest()[:16]
 	return digest + "_" + pathlib.Path(relative_filename).name
+
+
+def get_game_version_2019(game_data_dir: pathlib.Path) -> Optional[str]:
+	"""
+	Unity 2019 games (HSR) keep the version string in 'data.unity3d'
+	instead of 'globalgamemanagers'.
+	"""
+	unity3d_path = game_data_dir / "data.unity3d"
+	with open(unity3d_path, "rb") as f:
+		view = f.read()
+
+	index = view.find(b"category")
+	if index == -1:
+		raise ValueError("pattern not found")
+
+	for j in range(index, min(index + 0x80, len(view) - 3)):
+		if view[j] == 0x2e and view[j + 2] == 0x2e:
+			return "%c.%c.%c" % (view[j - 1], view[j + 1], view[j + 3])
+
+	raise ValueError("Failed to parse version")
 
 
 # -------------------
@@ -326,7 +355,7 @@ class DownloadInfo:
 class SophonClient:
 	installed_ver: None  # "major.minor.patch" or "new" for new installations
 	rel_type: str | None = None  # os / cn / bb
-	game_type: Literal["hk4e", "nap"] | None = None  # hk4e / nap
+	game_type: Literal["hk4e", "nap", "hkrpg"] | None = None  # hk4e / nap / hkrpg
 	gamedatadir: str | None= None # "*_Data"
 	branch: str          # main / pre_download
 	branches_json = None # package_id, password, tag
@@ -352,7 +381,7 @@ class SophonClient:
 			self.rel_type = OPT.install_reltype
 
 		if OPT.game_type:
-			assert OPT.game_type in ["hk4e", "nap"], "Unknown game type. Must be 'hk4e' or 'nap'."
+			assert OPT.game_type in ["hk4e", "nap", "hkrpg"], "Unknown game type. Must be 'hk4e', 'nap' or 'hkrpg'."
 			self.game_type = OPT.game_type
 
 		if OPT.do_install + OPT.do_update + isinstance(OPT.repair_mode, str) > 1:
@@ -399,6 +428,11 @@ class SophonClient:
 				"os": "[General]\r\nchannel=1\r\ncps=mihoyo\r\ngame_version=0.0.0\r\nsdk_version=\r\nsub_channel=0\r\n",
 				"cn": "[General]\r\nchannel=1\r\ncps=mihoyo\r\ngame_version=0.0.0\r\nsdk_version=\r\nsub_channel=1\r\n",
 			}
+		elif OPT.game_type == "hkrpg":
+			templates = {
+				"os": "[General]\r\nchannel=1\r\ncps=hoyoverse_PC\r\ngame_version=0.0.0\r\nsub_channel=1\r\n",
+				"cn": "[General]\r\nchannel=1\r\ncps=gw_PC\r\ngame_version=0.0.0\r\nsub_channel=1\r\n",
+			}
 		assert templates[self.rel_type], "Unknown reltype"
 		with gamedir("config.ini").open("w") as fh:
 			fh.write(templates[self.rel_type])
@@ -438,6 +472,17 @@ class SophonClient:
 			if not isinstance(self.rel_type, str):
 				abortlog("Failed to detect release type. " \
 				         + f"config.ini in '{OPT.gamedir}' has wrong information.")
+		elif self.game_type == "hkrpg":
+			# OS and CN share the same executable and sub_channel, so use cps
+			with open(gamedir("config.ini"), "r") as f:
+				contents = f.read()
+				if "cps=hoyoverse_PC" in contents:
+					self.rel_type = "os"
+				elif "cps=gw_PC" in contents:
+					self.rel_type = "cn"
+			if not isinstance(self.rel_type, str):
+				abortlog("Failed to detect release type. " \
+				         + f"config.ini in '{OPT.gamedir}' has wrong information.")
 
 		infolog(f"Release type: {self.rel_type}")
 
@@ -457,6 +502,11 @@ class SophonClient:
 				ver = get_game_version(gamedir(self.gamedatadir), 0xc4)
 				assert ver, "Failed to retrieve game version from globalgamemanagers"
 				self.installed_ver = ver
+			elif self.game_type == "hkrpg":
+				ver = get_game_version_2019(gamedir(self.gamedatadir))
+				assert ver, "Failed to retrieve game version from data.unity3d"
+				self.installed_ver = ver
+				infolog(f"Installed game version: {self.installed_ver} (anchor: data.unity3d)")
 		else:
 			# Change this if needed
 			self.installed_ver = "5.5.0"
@@ -491,6 +541,34 @@ class SophonClient:
 		else:
 			# equal version or lower
 			self.installed_ver = ver[0]
+
+
+	def get_installed_voiceover_categories(self) -> list:
+		"""
+		Audio categories present in the install, e.g. ["en-us", "ja-jp"].
+		Only implemented for hkrpg; the other games keep their own handling.
+		"""
+		if self.game_type != "hkrpg":
+			return []
+
+		self._get_gamedatadir()
+		audio_root = gamedir(self.gamedatadir, "Persistent/Audio/AudioPackage/Windows")
+		if not audio_root.is_dir():
+			infolog("No voiceover packs installed.")
+			return []
+
+		found = []
+		for entry in sorted(audio_root.iterdir()):
+			if not entry.is_dir():
+				continue
+			category = HKRPG_VOICEOVER_DIRS.get(entry.name)
+			if not category:
+				warnlog(f"Unknown voiceover directory '{entry.name}'")
+				continue
+			found.append(category)
+
+		infolog("Installed voiceover packs: " + (", ".join(found) if found else "none"))
+		return found
 
 
 	def get_voiceover_packs(self):
@@ -645,7 +723,7 @@ class SophonClient:
 		game_ids: str = None
 		launcher_id: str = None
 
-		assert self.game_type in ["hk4e", "nap", "hkrpg"], "Unknown game type. Must be 'hk4e' or 'nap'."
+		assert self.game_type in ["hk4e", "nap", "hkrpg"], "Unknown game type. Must be 'hk4e', 'nap' or 'hkrpg'."
 
 		if self.rel_type == "os":
 			# Up-to-date as of 2024-06-15 (4.7.0)
@@ -946,10 +1024,11 @@ class SophonClient:
 		filename = pathlib.Path(file_info.filename) # "UnityGame_Data/Subdirectory/file.txt"
 
 		# Check whether the file already exists.
-		# A file queued in `new_files_to_download` is there because the caller
-		# already found it wrong (repair md5 mismatch, failed patch). Its size can
-		# still match, so a size-only check would skip the files we were asked to
-		# restore.
+		# A file queued in `new_files_to_download` was put there by a caller that
+		# already decided it is wrong (a repair md5 mismatch, a failed patch). Its
+		# size can still match, so a size-only check here would skip the very files
+		# it was asked to restore, and "reliable" repair could never fix corruption
+		# that preserves the file size.
 		if file_info.filename not in self.new_files_to_download:
 			if try_get_file_size(gamedir(filename)) == file_info.size:
 				if install_progress_handler:
@@ -970,6 +1049,10 @@ class SophonClient:
 			return
 
 		# Download to the temporary directory. Move after we're done.
+		# The temporary name must be derived from the full relative path: several
+		# files share a base name (HSR has 46 'VFS.bytes' and 19 'AudioGround.bytes'),
+		# and downloads run concurrently, so a name-only temp file lets one file's
+		# chunks land in another file's path.
 		dstfile = tempdir(temp_name_for(file_info.filename))
 		bytes_written = 0
 

--- a/sophon_server/sophon_api.py
+++ b/sophon_server/sophon_api.py
@@ -945,12 +945,17 @@ class SophonClient:
 		filename_safety_check(file_info.filename)
 		filename = pathlib.Path(file_info.filename) # "UnityGame_Data/Subdirectory/file.txt"
 
-		# Check whether the file already exists
-		if try_get_file_size(gamedir(filename)) == file_info.size:
-			if install_progress_handler:
-				install_progress_handler.file_download_skipped(file_info.filename, "exists")
-			#infolog(f"File '{filename.name}' already exists. ")
-			return True
+		# Check whether the file already exists.
+		# A file queued in `new_files_to_download` is there because the caller
+		# already found it wrong (repair md5 mismatch, failed patch). Its size can
+		# still match, so a size-only check would skip the files we were asked to
+		# restore.
+		if file_info.filename not in self.new_files_to_download:
+			if try_get_file_size(gamedir(filename)) == file_info.size:
+				if install_progress_handler:
+					install_progress_handler.file_download_skipped(file_info.filename, "exists")
+				#infolog(f"File '{filename.name}' already exists. ")
+				return True
 
 		CHUNK_URL_PREFIX = self.di_chunks.category_json["chunk_download"]["url_prefix"]
 

--- a/sophon_server/tasks.py
+++ b/sophon_server/tasks.py
@@ -130,7 +130,8 @@ def perform_repair(manager: ConnectionManager, tasks: Dict[str, TaskStatus], tas
     cli.initialize(options)
     cli.retrieve_API_keys()
 
-    cli.repair_by_category("game", repair_progress_handler=progress, cancel_event=cancel_event)
+    for category in ["game"] + cli.get_installed_voiceover_categories():
+        cli.repair_by_category(category, repair_progress_handler=progress, cancel_event=cancel_event)
 
     del cli
     del options
@@ -158,13 +159,17 @@ def perform_update(manager: ConnectionManager, tasks: Dict[str, TaskStatus], tas
     cli = SophonClient()
     cli.initialize(options)
     cli.retrieve_API_keys()
-    cli.load_manifest("game")
 
-    if not options.predownload:
-        cli.process_deletefiles(progress_handler=progress)
+    # Voice packs are shipped as their own categories. Updating only "game"
+    # leaves them on the previous version, which the client will not load.
+    for category in ["game"] + cli.get_installed_voiceover_categories():
+        cli.load_manifest(category)
 
-    cli.apply_or_prepare_ldiff_files(progress_handler=progress)
-    cli.diff_download_new_files(progress_handler=progress)
+        if not options.predownload:
+            cli.process_deletefiles(progress_handler=progress)
+
+        cli.apply_or_prepare_ldiff_files(progress_handler=progress)
+        cli.diff_download_new_files(progress_handler=progress)
 
     if not options.predownload:
         cli.load_manifest("game")
@@ -178,9 +183,9 @@ def perform_update(manager: ConnectionManager, tasks: Dict[str, TaskStatus], tas
     if RUN_MEMORY_HACK:
         force_memory_release()
 
-def fetch_online_game_info(reltype: str, game: Literal["nap", "hk4e"]) -> OnlineGameInfo:
+def fetch_online_game_info(reltype: str, game: Literal["nap", "hk4e", "hkrpg"]) -> OnlineGameInfo:
     try:
-        if game in ["hk4e", "nap"]:
+        if game in ["hk4e", "nap", "hkrpg"]:
             options = Options()
             options.game_type = game
             options.install_reltype = reltype
@@ -237,7 +242,7 @@ def fetch_online_game_info(reltype: str, game: Literal["nap", "hk4e"]) -> Online
                 error=None
             )
         else:
-            raise ValueError("Unsupported game type. Only 'hk4e' and 'nap' is supported.")
+            raise ValueError("Unsupported game type. Only 'hk4e', 'nap' and 'hkrpg' are supported.")
     except Exception as e:
         return OnlineGameInfo(
             game_type="",

--- a/src/clients/hkrpgcn.ts
+++ b/src/clients/hkrpgcn.ts
@@ -38,6 +38,7 @@ export const SERVER_DEFINITION: Server = {
 export function createClient(options: CreateClientOptions) {
   return createHKRPGChannelClient({
     server: SERVER_DEFINITION,
+    releaseType: "cn",
     ...options,
   });
 }

--- a/src/clients/hkrpgos.ts
+++ b/src/clients/hkrpgos.ts
@@ -38,6 +38,7 @@ export const SERVER_DEFINITION: Server = {
 export function createClient(options: CreateClientOptions) {
   return createHKRPGChannelClient({
     server: SERVER_DEFINITION,
+    releaseType: "os",
     ...options,
   });
 }

--- a/src/clients/mhy/hkrpg/index.tsx
+++ b/src/clients/mhy/hkrpg/index.tsx
@@ -7,19 +7,23 @@ import {
 import { Server } from "@constants";
 import { Locale } from "@locale";
 import {
-  assertValueDefined,
   exec,
   getFreeSpace,
   getKey,
   getKeyOrDefault,
+  log,
+  rawString,
+  readAllLinesIfExists,
   setKey,
+  spawn,
   stats,
+  timeout,
   waitImageReady,
 } from "@utils";
 import { join } from "path-browserify";
 import { gt, lt } from "semver";
 import { Config } from "@config";
-import { checkIntegrityProgram } from "../program-check-integrity";
+import { checkIntegrityProgram } from "./program-check-integrity";
 import {
   predownloadGameProgram,
   updateGameProgram,
@@ -28,56 +32,64 @@ import { downloadAndInstallGameProgram } from "./program-install-game";
 import { launchGameProgram } from "./program-launch-game";
 import { patchRevertProgram } from "../patch";
 import { Aria2 } from "@aria2";
+import { Sophon, createSophonRetry } from "@sophon";
 import { Wine } from "@wine";
 import {
   checkAndDownloadDXMT,
-  checkAndDownloadDXVK,
   checkAndDownloadJadeite,
   checkAndDownloadReshade,
 } from "../../../downloadable-resource";
 import { getGameVersion2019 } from "../unity";
-import {
-  HoyoConnectGameBackgroundType,
-  VoicePackNames,
-} from "../launcher-info";
+import { HoyoConnectGameBackgroundType } from "../launcher-info";
 import createPatchOff from "./config/patch-off";
 import createBlockNet from "./config/block-net";
-import { getLatestAdvInfo, getLatestVersionInfo } from "../hyp-connect";
-
-// no need to check supported version
-// const CURRENT_SUPPORTED_VERSION = "4.3.0";
+import { getLatestAdvInfo } from "../hyp-connect";
 
 export async function createHKRPGChannelClient({
   server,
   locale,
   aria2,
   wine,
+  releaseType,
 }: {
   server: Server;
   locale: Locale;
   aria2: Aria2;
   wine: Wine;
+  releaseType: "os" | "cn";
 }): Promise<ChannelClient> {
   const {
     background: { url: background },
-    icon: { url: icon, link: icon_link },
+    icon: { link: icon_link },
     video: { url: video_url },
     theme: { url: theme_url },
     type: bg_type,
   } = await getLatestAdvInfo(locale, server);
   const IS_VIDEO_BG =
     bg_type === HoyoConnectGameBackgroundType.BACKGROUND_TYPE_VIDEO;
-  const {
-    main: {
-      major: {
-        version: GAME_LATEST_VERSION,
-        game_pkgs,
-        res_list_url: decompressed_path,
-      },
-      patches,
-    },
-    pre_download,
-  } = await getLatestVersionInfo(server);
+
+  const sophon_port = Math.floor(Math.random() * (65535 - 40000)) + 40000;
+  const sophon_host = "127.0.0.1";
+
+  const pid = (await exec(["echo", rawString("$PPID")])).stdOut.split("\n")[0];
+  await spawn(["./sidecar/sophon_server/sophon-server"], {
+    TERMINATE_WITH_PID: pid,
+    SOPHON_PORT: sophon_port.toString(),
+    SOPHON_HOST: sophon_host,
+  });
+  const sophon = await Promise.race([
+    createSophonRetry(sophon_host, sophon_port),
+    timeout(30000),
+  ]).catch(() => Promise.reject(new Error("Fail to launch sophon.")));
+
+  const gameInfo = await sophon.getLatestOnlineGameInfo(releaseType, "hkrpg");
+  log(`Game info: ${JSON.stringify(gameInfo)}`);
+  const LATEST_GAME_VERSION: string = gameInfo.version;
+  const UPDATABLE_VERSIONS: string[] = gameInfo.updatable_versions;
+  const PRE_DOWNLOAD_VERSION: string = gameInfo.pre_download_version || "0.0.0";
+  const PRE_DOWNLOAD_AVAILABLE: boolean = gameInfo.pre_download;
+  const INSTALL_SIZE_BYTES: number = gameInfo.install_size;
+
   await waitImageReady(background);
 
   const { gameInstalled, gameInstallDir, gameVersion } = await checkGameState(
@@ -90,11 +102,11 @@ export async function createHKRPGChannelClient({
   );
   const [showPredownloadPrompt, setShowPredownloadPrompt] =
     createSignal<boolean>(
-      pre_download.major != null && //exist pre_download_game data in server response
+      PRE_DOWNLOAD_AVAILABLE &&
         (await getKeyOrDefault("predownloaded_all", "NOTFOUND")) ==
           "NOTFOUND" && // not downloaded yet
         gameInstalled && // game installed
-        gt(pre_download.major.version, gameVersion) // predownload version is greater
+        gt(PRE_DOWNLOAD_VERSION, gameVersion) // predownload version is greater
     );
   const [_gameInstallDir, setGameInstallDir] = createSignal(
     gameInstallDir ?? ""
@@ -102,7 +114,7 @@ export async function createHKRPGChannelClient({
   const [gameCurrentVersion, setGameVersion] = createSignal(
     gameVersion ?? "0.0.0"
   );
-  const updateRequired = () => lt(gameCurrentVersion(), GAME_LATEST_VERSION);
+  const updateRequired = () => lt(gameCurrentVersion(), LATEST_GAME_VERSION);
   return {
     installState: installed,
     showPredownloadPrompt,
@@ -114,21 +126,18 @@ export async function createHKRPGChannelClient({
       background_theme: IS_VIDEO_BG ? theme_url : undefined,
       url: icon_link,
     },
-    predownloadVersion: () => pre_download?.major?.version ?? "",
+    predownloadVersion: () =>
+      PRE_DOWNLOAD_AVAILABLE ? PRE_DOWNLOAD_VERSION : "",
     dismissPredownload() {
       setShowPredownloadPrompt(false);
     },
     async *install(selection: string): CommonUpdateProgram {
       try {
-        // await stats(join(selection, "pkg_version"));
         await stats(join(selection, "GameAssembly.dll")); // FIXME: no pkg_version?
       } catch {
         const freeSpaceGB = await getFreeSpace(selection, "g");
-        const totalSize = game_pkgs
-          .map(x => x.size)
-          .map(parseInt)
-          .reduce((a, b) => a + b, 0);
-        const requiredSpaceGB = Math.ceil(totalSize / Math.pow(1024, 3)) * 1.2;
+        const requiredSpaceGB =
+          Math.ceil(INSTALL_SIZE_BYTES / Math.pow(1024, 3)) * 1.2;
         if (freeSpaceGB < requiredSpaceGB) {
           await locale.alert(
             "NO_ENOUGH_DISKSPACE",
@@ -139,35 +148,22 @@ export async function createHKRPGChannelClient({
         }
 
         yield* downloadAndInstallGameProgram({
-          aria2,
+          sophonClient: sophon,
           gameDir: selection,
-          gameSegmentZips: game_pkgs.map(x => x.url),
-          gameVersion: GAME_LATEST_VERSION,
-          server,
+          installReltype: releaseType,
         });
         // setGameInstalled
         batch(() => {
           setInstalled("INSTALLED");
           setGameInstallDir(selection);
-          setGameVersion(GAME_LATEST_VERSION);
+          setGameVersion(LATEST_GAME_VERSION);
         });
         await setKey("game_install_dir", selection);
         return;
       }
-      const gameVersion = await getGameVersion2019(
-        join(selection, server.dataDir)
-      );
-      // if (gt(gameVersion, CURRENT_SUPPORTED_VERSION)) {
-      //   await locale.alert(
-      //     "UNSUPPORTED_VERSION",
-      //     "PLEASE_WAIT_FOR_LAUNCHER_UPDATE",
-      //     [gameVersion]
-      //   );
-      //   return;
-      // } else
-      if (lt(gameVersion, GAME_LATEST_VERSION)) {
-        const updateTarget = patches.find(x => x.version == gameVersion);
-        if (!updateTarget) {
+      const gameVersion = await getInstalledVersion(selection, server);
+      if (lt(gameVersion, LATEST_GAME_VERSION)) {
+        if (!UPDATABLE_VERSIONS.includes(gameVersion)) {
           await locale.prompt(
             "UNSUPPORTED_VERSION",
             "GAME_VERSION_TOO_OLD_DESC",
@@ -184,9 +180,8 @@ export async function createHKRPGChannelClient({
         // FIXME: perform a integrity check?
       } else {
         yield* checkIntegrityProgram({
-          aria2,
+          sophon,
           gameDir: selection,
-          remoteDir: decompressed_path,
         });
         // setGameInstalled
         batch(() => {
@@ -199,48 +194,14 @@ export async function createHKRPGChannelClient({
     },
     async *predownload() {
       setShowPredownloadPrompt(false);
-      if (pre_download.major == null) return;
-      const updateTarget = pre_download.patches.find(
-        x => x.version == gameCurrentVersion()
-      );
-      if (updateTarget == null) return;
-      const voicePacks = (
-        await Promise.all(
-          updateTarget.audio_pkgs.map(async x => {
-            try {
-              await stats(
-                join(
-                  _gameInstallDir(),
-                  `Audio_${VoicePackNames[x.language]}_pkg_version`
-                )
-              );
-              return x;
-            } catch {
-              return null;
-            }
-          })
-        )
-      )
-        .filter(x => x != null)
-        .map(x => {
-          assertValueDefined(x);
-          return x;
-        });
-      if (updateTarget.game_pkgs.length != 1) {
-        throw new Error(
-          "assertation failed (game_pkgs.length!= 1)! please file an issue."
-        );
-      }
+      if (!PRE_DOWNLOAD_AVAILABLE) return;
       yield* predownloadGameProgram({
-        aria2,
-        updateFileZip: updateTarget.game_pkgs[0].url,
+        sophon,
         gameDir: _gameInstallDir(),
-        updateVoicePackZips: voicePacks.map(x => x.url),
       });
     },
     async *update() {
-      const updateTarget = patches.find(x => x.version == gameCurrentVersion());
-      if (!updateTarget) {
+      if (!UPDATABLE_VERSIONS.includes(gameCurrentVersion())) {
         await locale.prompt(
           "UNSUPPORTED_VERSION",
           "GAME_VERSION_TOO_OLD_DESC",
@@ -254,58 +215,15 @@ export async function createHKRPGChannelClient({
         await setKey("game_install_dir", null);
         return;
       }
-      const voicePacks = (
-        await Promise.all(
-          updateTarget.audio_pkgs.map(async x => {
-            try {
-              await stats(
-                join(
-                  _gameInstallDir(),
-                  `Audio_${VoicePackNames[x.language]}_pkg_version`
-                )
-              );
-              return x;
-            } catch {
-              return null;
-            }
-          })
-        )
-      )
-        .filter(x => x != null)
-        .map(x => {
-          assertValueDefined(x);
-          return x;
-        });
-      if (updateTarget.game_pkgs.length != 1) {
-        throw new Error(
-          "assertation failed (game_pkgs.length!= 1)! please file an issue."
-        );
-      }
       yield* updateGameProgram({
-        aria2,
-        server,
-        currentGameVersion: gameCurrentVersion(),
-        updatedGameVersion: GAME_LATEST_VERSION,
-        updateFileZip: updateTarget.game_pkgs[0].url,
+        sophon,
         gameDir: _gameInstallDir(),
-        updateVoicePackZips: voicePacks.map(x => x.url),
       });
       batch(() => {
-        setGameVersion(GAME_LATEST_VERSION);
+        setGameVersion(LATEST_GAME_VERSION);
       });
     },
     async *launch(config: Config) {
-      // if (
-      //   gt(gameCurrentVersion(), CURRENT_SUPPORTED_VERSION) &&
-      //   !config.patchOff
-      // ) {
-      //   await locale.alert(
-      //     "UNSUPPORTED_VERSION",
-      //     "PLEASE_WAIT_FOR_LAUNCHER_UPDATE",
-      //     [gameCurrentVersion()]
-      //   );
-      //   return;
-      // }
       if (config.reshade) {
         yield* checkAndDownloadReshade(aria2, wine, _gameInstallDir());
       }
@@ -322,11 +240,9 @@ export async function createHKRPGChannelClient({
       });
     },
     async *checkIntegrity() {
-      // FIXME: no pkg_version?
       yield* checkIntegrityProgram({
-        aria2,
+        sophon,
         gameDir: _gameInstallDir(),
-        remoteDir: decompressed_path,
       });
     },
     async *init(config: Config) {
@@ -339,9 +255,8 @@ export async function createHKRPGChannelClient({
         yield* patchRevertProgram(_gameInstallDir(), wine, server, config);
       } catch {
         yield* checkIntegrityProgram({
-          aria2,
+          sophon,
           gameDir: _gameInstallDir(),
-          remoteDir: decompressed_path,
         });
       }
     },
@@ -354,6 +269,27 @@ export async function createHKRPGChannelClient({
       };
     },
   };
+}
+
+/**
+ * data.unity3d is rewritten early during an update while config.ini is only
+ * rewritten once the whole update succeeds. The game reads config.ini, so an
+ * interrupted update leaves the launcher believing it is done while the game
+ * refuses to start. Report the lower of the two, the way the sophon server does.
+ */
+async function getInstalledVersion(gameDir: string, server: Server) {
+  const unityVersion = await getGameVersion2019(join(gameDir, server.dataDir));
+  const lines = await readAllLinesIfExists(join(gameDir, "config.ini"));
+  const configVersion = lines
+    .map(line => /^game_version=(\d+\.\d+\.\d+)/.exec(line.trim())?.[1])
+    .find(version => version != undefined);
+  if (configVersion && lt(configVersion, unityVersion)) {
+    log(
+      `config.ini reports ${configVersion} while data.unity3d reports ${unityVersion}; the update did not finish`
+    );
+    return configVersion;
+  }
+  return unityVersion;
 }
 
 async function checkGameState(locale: Locale, server: Server) {
@@ -369,7 +305,7 @@ async function checkGameState(locale: Locale, server: Server) {
     return {
       gameInstalled: true,
       gameInstallDir: gameDir,
-      gameVersion: await getGameVersion2019(join(gameDir, server.dataDir)),
+      gameVersion: await getInstalledVersion(gameDir, server),
     } as const;
   } catch {
     return {

--- a/src/clients/mhy/hkrpg/program-check-integrity.ts
+++ b/src/clients/mhy/hkrpg/program-check-integrity.ts
@@ -1,32 +1,36 @@
 import { basename } from "path-browserify";
-import { SophonClient } from "@sophon";
+import { Sophon } from "@sophon";
 import { CommonUpdateProgram } from "@common-update-ui";
-import { humanFileSize, log } from "@utils";
+import { humanFileSize } from "@utils";
 
-export async function* downloadAndInstallGameProgram({
-  sophonClient,
+export async function* checkIntegrityProgram({
+  sophon,
   gameDir,
-  installReltype,
 }: {
-  sophonClient: SophonClient;
   gameDir: string;
-  installReltype: string;
+  sophon: Sophon;
 }): CommonUpdateProgram {
-  yield ["setUndeterminedProgress"];
-  log("Starting game installation process...");
-
-  const taskId = await sophonClient.startInstallation({
+  const taskId = await sophon.startRepair({
     gamedir: gameDir,
     game_type: "hkrpg",
-    install_reltype: installReltype,
+    repair_mode: "reliable",
   });
-  log(`Installation task started with ID: ${taskId}`);
 
-  for await (const progress of sophonClient.streamOperationProgress(taskId)) {
+  yield ["setStateText", "SCANNING_FILES", "0", "0"];
+
+  for await (const progress of sophon.streamOperationProgress(taskId)) {
     switch (progress.type) {
-      case "job_start":
-        yield ["setUndeterminedProgress"];
-        yield ["setStateText", "ALLOCATING_FILE"];
+      case "check_file":
+        yield [
+          "setStateText",
+          "SCANNING_FILES",
+          String(progress.overall_progress.checked_files),
+          String(progress.overall_progress.total_files),
+        ];
+        yield [
+          "setProgress",
+          Number(progress.overall_progress.overall_percent),
+        ];
         break;
 
       case "chunk_progress":

--- a/src/clients/mhy/hkrpg/program-update-game.ts
+++ b/src/clients/mhy/hkrpg/program-update-game.ts
@@ -1,243 +1,79 @@
 import { join, basename } from "path-browserify";
-import { Aria2 } from "@aria2";
+import { Sophon } from "@sophon";
 import { CommonUpdateProgram } from "@common-update-ui";
-import { Server } from "@constants";
-import {
-  mkdirp,
-  humanFileSize,
-  doStreamUnzip,
-  removeFile,
-  writeFile,
-  hpatchz,
-  forceMove,
-  readAllLinesIfExists,
-  removeFileIfExists,
-  getKey,
-  stats,
-  setKey,
-  exec,
-  getKeyOrDefault,
-  fileOrDirExists,
-  extract7z,
-} from "@utils";
-import { gte } from "semver";
+import { humanFileSize, setKey } from "@utils";
 
-//https://stackoverflow.com/a/69399958
-const sha1sum = async (message: string) => {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(message);
-  const hashBuffer = await crypto.subtle.digest("SHA-1", data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer)); // convert buffer to byte array
-  const hashHex = hashArray.map(b => b.toString(16).padStart(2, "0")).join(""); // convert bytes to hex string
-  return hashHex;
-};
-
-async function* downloadAndPatch(
-  updateFileZip: string,
-  gameDir: string,
-  aria2: Aria2
+async function* streamProgress(
+  sophon: Sophon,
+  taskId: string,
+  withPatching: boolean
 ): CommonUpdateProgram {
-  const downloadTmp = join(gameDir, ".ariatmp");
-  await mkdirp(downloadTmp);
-  const updateFileTmp = join(downloadTmp, basename(updateFileZip));
-
-  try {
-    await getKey(
-      `predownloaded_${(await sha1sum(basename(updateFileZip))).slice(0, 32)}`
-    );
-    await stats(updateFileTmp);
-  } catch {
-    yield ["setUndeterminedProgress"];
-    yield ["setStateText", "ALLOCATING_FILE"];
-    let gameFileStart = false;
-    for await (const progress of aria2.doStreamingDownload({
-      uri: updateFileZip,
-      absDst: updateFileTmp,
-    })) {
-      if (!gameFileStart && progress.downloadSpeed == BigInt(0)) {
-        continue;
-      }
-      gameFileStart = true;
-      yield [
-        "setStateText",
-        "DOWNLOADING_FILE_PROGRESS",
-        basename(updateFileZip),
-        humanFileSize(Number(progress.downloadSpeed)),
-        humanFileSize(Number(progress.completedLength)),
-        humanFileSize(Number(progress.totalLength)),
-      ];
-      yield [
-        "setProgress",
-        Number(
-          (progress.completedLength * BigInt(10000)) / progress.totalLength
-        ) / 100,
-      ];
-    }
-  } finally {
-    await setKey(
-      `predownloaded_${(await sha1sum(basename(updateFileZip))).slice(0, 32)}`,
-      null
-    );
-  }
-
-  yield ["setStateText", "DECOMPRESS_FILE_PROGRESS"];
   yield ["setUndeterminedProgress"];
-  await extract7z(updateFileTmp, gameDir);
-  await removeFile(updateFileTmp);
+  yield ["setStateText", "ALLOCATING_FILE"];
+  for await (const progress of sophon.streamOperationProgress(taskId)) {
+    switch (progress.type) {
+      case "delete_file":
+      case "delete_ldiff_file":
+        if (!withPatching) break;
+        yield ["setStateText", "PATCHING"];
+        yield [
+          "setProgress",
+          Number(progress.overall_progress.overall_percent),
+        ];
+        break;
 
-  yield ["setStateText", "PATCHING"];
-  // delete files
-  const deleteList = (
-    await readAllLinesIfExists(join(gameDir, "deletefiles.txt"))
-  ).filter(x => x.trim() != "");
-
-  async function readJsonIfExists(filePath: string): Promise<any> {
-    try {
-      const content = await readAllLinesIfExists(filePath);
-      return JSON.parse(content.join("\n"));
-    } catch (error) {
-      return { diff_map: [] };
+      case "ldiff_download_complete":
+      case "chunk_progress":
+        yield [
+          "setStateText",
+          "DOWNLOADING_FILE_PROGRESS",
+          basename(progress.filename),
+          humanFileSize(progress.overall_progress.download_speed),
+          humanFileSize(progress.overall_progress.downloaded_size),
+          humanFileSize(progress.overall_progress.total_size),
+        ];
+        yield [
+          "setProgress",
+          Number(progress.overall_progress.overall_percent),
+        ];
+        break;
     }
   }
-  const diffList: {
-    sourceFile: string;
-    targetFile: string;
-    patchFile: string;
-  }[] = (await readJsonIfExists(join(gameDir, "hdiffmap.json"))).diff_map.map(
-    (entry: any) => ({
-      sourceFile: entry.source_file_name,
-      targetFile: entry.target_file_name,
-      patchFile: entry.patch_file_name,
-    })
-  );
-
-  const patchCount = deleteList.length + diffList.length;
-  let doneCount = 0;
-
-  for (const file of deleteList) {
-    await removeFile(join(gameDir, file));
-    doneCount++;
-    yield ["setProgress", (doneCount / patchCount) * 100];
-  }
-  await removeFileIfExists(join(gameDir, "deletefiles.txt"));
-  // diff files
-
-  for (const { sourceFile, patchFile, targetFile } of diffList) {
-    await hpatchz(
-      join(gameDir, sourceFile),
-      join(gameDir, patchFile),
-      join(gameDir, targetFile)
-    );
-    // await forceMove(join(gameDir, sourceFile), join(gameDir,targetFile));
-    await removeFile(join(gameDir, patchFile));
-    doneCount++;
-    yield ["setProgress", (doneCount / patchCount) * 100];
-  }
-  await removeFileIfExists(join(gameDir, "hdiffmap.json"));
   yield ["setUndeterminedProgress"];
 }
 
 export async function* updateGameProgram({
-  aria2,
-  updateFileZip,
+  sophon,
   gameDir,
-  currentGameVersion,
-  updatedGameVersion,
-  server,
-  updateVoicePackZips,
 }: {
-  updateFileZip: string;
+  sophon: Sophon;
   gameDir: string;
-  currentGameVersion: string;
-  updatedGameVersion: string;
-  aria2: Aria2;
-  server: Server;
-  updateVoicePackZips: string[];
 }): CommonUpdateProgram {
   yield ["setStateText", "UPDATING"];
-
-  yield* downloadAndPatch(updateFileZip, gameDir, aria2);
-
-  for (const updateVoicePackZip of updateVoicePackZips) {
-    yield* downloadAndPatch(updateVoicePackZip, gameDir, aria2);
-  }
-
+  const taskId = await sophon.startUpdate({
+    gamedir: gameDir,
+    game_type: "hkrpg",
+    tempdir: join(gameDir, ".tmp"),
+    predownload: false,
+  });
+  yield* streamProgress(sophon, taskId, true);
   await setKey(`predownloaded_all`, null);
-  await writeFile(
-    join(gameDir, "config.ini"),
-    `[General]
-game_version=${updatedGameVersion}
-channel=${server.channel_id}
-sub_channel=${server.subchannel_id}
-cps=${server.cps}`
-  );
-}
-
-async function* predownload(
-  updateFileZip: string,
-  gameDir: string,
-  aria2: Aria2
-): CommonUpdateProgram {
-  const downloadTmp = join(gameDir, ".ariatmp");
-  await mkdirp(downloadTmp);
-  const updateFileTmp = join(downloadTmp, basename(updateFileZip));
-
-  if (
-    (await getKeyOrDefault(
-      `predownloaded_${(await sha1sum(basename(updateFileZip))).slice(0, 32)}`,
-      `NOTFOUND`
-    )) !== "NOTFOUND"
-  ) {
-    return;
-  }
-
-  yield ["setUndeterminedProgress"];
-  yield ["setStateText", "ALLOCATING_FILE"];
-  let gameFileStart = false;
-  for await (const progress of aria2.doStreamingDownload({
-    uri: updateFileZip,
-    absDst: updateFileTmp,
-  })) {
-    if (!gameFileStart && progress.downloadSpeed == BigInt(0)) {
-      continue;
-    }
-    gameFileStart = true;
-    yield [
-      "setStateText",
-      "DOWNLOADING_FILE_PROGRESS",
-      basename(updateFileZip),
-      humanFileSize(Number(progress.downloadSpeed)),
-      humanFileSize(Number(progress.completedLength)),
-      humanFileSize(Number(progress.totalLength)),
-    ];
-    yield [
-      "setProgress",
-      Number(
-        (progress.completedLength * BigInt(10000)) / progress.totalLength
-      ) / 100,
-    ];
-  }
-  await setKey(
-    `predownloaded_${(await sha1sum(basename(updateFileZip))).slice(0, 32)}`,
-    "true"
-  );
+  // config.ini is written by the sophon server
 }
 
 export async function* predownloadGameProgram({
+  sophon,
   gameDir,
-  updateFileZip,
-  aria2,
-  updateVoicePackZips,
 }: {
-  updateFileZip: string;
+  sophon: Sophon;
   gameDir: string;
-  aria2: Aria2;
-  updateVoicePackZips: string[];
-}) {
-  yield* predownload(updateFileZip, gameDir, aria2);
-
-  for (const updateVoicePackZip of updateVoicePackZips) {
-    yield* predownload(updateVoicePackZip, gameDir, aria2);
-  }
+}): CommonUpdateProgram {
+  const taskId = await sophon.startUpdate({
+    gamedir: gameDir,
+    game_type: "hkrpg",
+    tempdir: join(gameDir, ".tmp"),
+    predownload: true,
+  });
+  yield* streamProgress(sophon, taskId, false);
   await setKey(`predownloaded_all`, "true");
 }

--- a/src/sophon.ts
+++ b/src/sophon.ts
@@ -1,8 +1,10 @@
 import { log } from "@utils";
 
+export type GameType = "hk4e" | "nap" | "hkrpg";
+
 interface GameOperationOptions {
   gamedir: string;
-  game_type: string; // "hk4e" or "nap"
+  game_type: GameType; // "hk4e", "nap" or "hkrpg"
   tempdir?: string; // sophon manifest and intermediate files
 }
 
@@ -33,7 +35,7 @@ export interface SophonProgressEvent {
 }
 
 export interface SophonOnlineGameInfo {
-  game_type: "hk4e" | "nap" | "";
+  game_type: GameType | "";
   version: string;
   install_size: number;
   updatable_versions: string[];


### PR DESCRIPTION
Builds on #755 — the first two commits are that PR, review this one on top of it.

`getGamePackages` is pinned at HSR 4.4.0 while `getGameBranches` reports 4.5.0, so the launcher patched the game to 4.4.0 and the client refused to start asking for a newer launcher (#752). This routes HSR through the sophon sidecar the way hk4e already does.

- `sophon_server` accepts `hkrpg`: config.ini templates, release type detection (OS and CN share `sub_channel`, so it keys on `cps`) and version detection (Unity 2019 keeps the version in `data.unity3d`, not `globalgamemanagers`). The game ids were already there.
- Update and repair cover the installed voice packs, not just `game`. Leaving them on the old version makes the client hang on a black screen after the graphics device is created.
- Installed version is the lower of `data.unity3d` and `config.ini`. `data.unity3d` is replaced early in an update and `config.ini` only at the end, so an interrupted update otherwise looks finished in the UI with no way to resume.
- Sidecar is shipped in both HSR bundles.

Tested on HSR 4.5.0 OS, Apple M5 / macOS 26.6, Wine 11.0-1 crossover: 4.4.0 -> 4.5.0 update, integrity check, and launch. CN is untouched by testing — I only have an OS account, and `sophon_api` already warns CN is untested.

Happy to close this if the Swift rewrite mentioned in #752 lands first.